### PR TITLE
release: 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axocli"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 description = "common code for setting up a CLI App and handling errors/printing."
 repository = "https://github.com/axodotdev/axocli"


### PR DESCRIPTION
Like https://github.com/axodotdev/axoasset/pull/83, this is a new version purely to get the new miette in; it's a prerequisite to updating miette in cargo-dist, since we need everything on 6.0.0 or later to be able to upgrade past 5.x.