### PR TITLE
fix: clippy warning

### DIFF
--- a/examples/axoapp.rs
+++ b/examples/axoapp.rs
@@ -40,7 +40,7 @@ fn run(app: &axocli::CliApp<CliArgs>) -> Result<(), Report> {
         "i have no exclamation marks but i must scream"
     );
     if app.config.exclaim_count < 3 {
-        return Err(AxoAppError::NotExcitedEnough)?;
+        Err(AxoAppError::NotExcitedEnough)?;
     }
     let message = "hello axoapp";
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,6 +154,9 @@ impl CliAppBuilder {
             if let Some(msg) = payload.downcast_ref::<&str>() {
                 message = msg.to_string();
             }
+            // This is being moved to pedantic in 1.80.0; just
+            // tag an allow for now and remove later.
+            #[allow(clippy::assigning_clones)]
             if let Some(msg) = payload.downcast_ref::<String>() {
                 message = msg.clone();
             }


### PR DESCRIPTION
This is going to turn into a pedantic warning in 1.79.0 or 1.80.0; I'd rather just disable the warning rather than make a change that reduces readability when clippy isn't going to bother us about it in the future.