### PR TITLE
fix: loosen backtrace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-backtrace = "0.3.71"
+backtrace = "0.3.69"
 backtrace-ext = "0.2.1"
 console = "0.15.8"
 miette = { version = "7.2.0", features = ["fancy"] }


### PR DESCRIPTION
This was committed before we started being more careful about Cargo.toml.