### PR TITLE
fix: relax serde_json

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ backtrace-ext = "0.2.1"
 console = "0.15.8"
 miette = { version = "7.2.0", features = ["fancy"] }
 serde = "1.0.200"
-serde_json = "1.0.114"
+serde_json = "1.0.95"
 thiserror = "1.0.60"
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"


### PR DESCRIPTION
This was bumped before we started being careful about Cargo.toml.